### PR TITLE
rewrites the cartogram_cont.sf function 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cartogram
 Title: Create Cartograms with R
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c(
   person("Sebastian", "Jeworutzki", email = "sebastian.jeworutzki@ruhr-uni-bochum.de", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-2671-5253")),
   person("Timothee", "Giraud", role = "ctb"),
@@ -17,4 +17,4 @@ Suggests: rgdal, maptools
 License: GPL-3
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.1

--- a/man/cartogram_cont.Rd
+++ b/man/cartogram_cont.Rd
@@ -9,11 +9,12 @@
 cartogram_cont(x, weight, itermax = 15, maxSizeError = 1.0001,
   prepare = "adjust", threshold = 0.05)
 
-\method{cartogram_cont}{SpatialPolygonsDataFrame}(x, weight, itermax = 15,
-  maxSizeError = 1.0001, prepare = "adjust", threshold = 0.05)
+\method{cartogram_cont}{SpatialPolygonsDataFrame}(x, weight,
+  itermax = 15, maxSizeError = 1.0001, prepare = "adjust",
+  threshold = 0.05)
 
-\method{cartogram_cont}{sf}(x, weight, itermax = 15, maxSizeError = 1.0001,
-  prepare = "adjust", threshold = 0.05)
+\method{cartogram_cont}{sf}(x, weight, itermax = 15,
+  maxSizeError = 1.0001, prepare = "adjust", threshold = 0.05)
 }
 \arguments{
 \item{x}{SpatialPolygonDataFrame or an sf object}

--- a/man/checkPolygonsGEOS.Rd
+++ b/man/checkPolygonsGEOS.Rd
@@ -4,7 +4,8 @@
 \alias{checkPolygonsGEOS}
 \title{Check polygons}
 \usage{
-checkPolygonsGEOS(obj, properly = TRUE, force = TRUE, useSTRtree = FALSE)
+checkPolygonsGEOS(obj, properly = TRUE, force = TRUE,
+  useSTRtree = FALSE)
 }
 \arguments{
 \item{obj}{Polygons object}


### PR DESCRIPTION
I've removed some repeated calculations and unnecessary conversions. The results are exactly the same, but the calculation time is desreased by a factor of 3.

```
> bench::mark(
+   afr_sf_carto <- cartogram_cont(afr_sf, "POP2005", 3),
+   afr_sf_carto2 <- cartogram_cont_new(afr_sf, "POP2005", 3),
+   iterations = 10
+ )
Mean size error for iteration 1: 5.21860496451407
Mean size error for iteration 2: 4.2953828836314
Mean size error for iteration 3: 3.64845131419451
Mean size error for iteration 1: 5.21860496451407
Mean size error for iteration 2: 4.2953828836314
Mean size error for iteration 3: 3.64845131419452
# A tibble: 2 x 14
  expression                min     mean   median      max `itr/sec` mem_alloc  n_gc n_itr total_time result  memory   time  gc     
  <chr>                <bch:tm> <bch:tm> <bch:tm> <bch:tm>     <dbl> <bch:byt> <dbl> <int>   <bch:tm> <list>  <list>   <lis> <list> 
1 "afr_sf_carto <- ca…    1.31s    1.83s     1.6s    2.56s     0.548        0B    53    10     18.26s <sf [5… <Rprofm… <bch… <tibbl…
2 "afr_sf_carto2 <- c… 504.31ms 553.53ms  534.3ms 647.34ms     1.81         0B    30    10      5.54s <sf [5… <Rprofm… <bch… <tibbl…
```