### PR TITLE
fixes polygon error

### DIFF
--- a/R/cartogram_cont.R
+++ b/R/cartogram_cont.R
@@ -213,7 +213,6 @@ cartogram_cont.sf <- function(x, weight, itermax = 15, maxSizeError = 1.0001,
   # prepare data
   value <- x[[weight]]
   
-  
   switch(prepare,
          # remove missing and values below threshold
          "remove" = {
@@ -292,8 +291,8 @@ cartogram_cont.sf <- function(x, weight, itermax = 15, maxSizeError = 1.0001,
     
     for (i in seq_len(nrow(x.iter))) {
       pts <- st_coordinates(x.iter_geom[[i]])
-      idx <- unique(pts[, c("L1", "L2", "L3")])
-      
+      idx <- unique(pts[, colnames(pts) %in% c("L1", "L2", "L3")])
+
       for (k in seq_len(nrow(idx))) {
         newpts <- pts[pts[, "L1"] == idx[k, "L1"] & pts[, "L2"] == idx[k, "L2"], c("X", "Y")]
         distances <- spDists(newpts, centroids)
@@ -313,7 +312,11 @@ cartogram_cont.sf <- function(x, weight, itermax = 15, maxSizeError = 1.0001,
         }
         
         # save final coordinates from this iteration to coordinate list
-        st_geometry(x.iter)[[i]][[idx[k, "L2"]]][[idx[k, "L1"]]] <- newpts
+        if (st_geometry_type(st_geometry(x.iter)[[i]]) == "POLYGON"){
+          st_geometry(x.iter)[[i]][[idx[k, "L1"]]] <- newpts
+        } else {
+          st_geometry(x.iter)[[i]][[idx[k, "L2"]]][[idx[k, "L1"]]] <- newpts
+        }
       }
     }
   }


### PR DESCRIPTION
It fixes https://github.com/sjewo/cartogram/issues/19. Importantly, users should not just use `st_cast()`, because it would create several rows (geometries) of different areas but with the same values. 

``` r
library(spData)
library(cartogram)
library(tmap)
library(sf)
#> Linking to GEOS 3.7.1, GDAL 2.3.2, PROJ 5.2.0

nz
#> Simple feature collection with 16 features and 6 fields
#> geometry type:  MULTIPOLYGON
#> dimension:      XY
#> bbox:           xmin: 1090144 ymin: 4748537 xmax: 2089533 ymax: 6191874
#> epsg (SRID):    2193
#> proj4string:    +proj=tmerc +lat_0=0 +lon_0=173 +k=0.9996 +x_0=1600000 +y_0=10000000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs
#> First 10 features:
#>                 Name Island Land_area Population Median_income Sex_ratio
#> 1          Northland  North 12500.561     175500         23400 0.9424532
#> 2           Auckland  North  4941.573    1657200         29600 0.9442858
#> 3            Waikato  North 23900.036     460100         27900 0.9520500
#> 4      Bay of Plenty  North 12071.145     299900         26200 0.9280391
#> 5           Gisborne  North  8385.827      48500         24400 0.9349734
#> 6        Hawke's Bay  North 14137.524     164000         26100 0.9238375
#> 7           Taranaki  North  7254.480     118000         29100 0.9569363
#> 8  Manawatu-Wanganui  North 22220.608     234500         25000 0.9387734
#> 9         Wellington  North  8048.553     513900         32700 0.9335524
#> 10        West Coast  South 23245.456      32400         26900 1.0139072
#>                              geom
#> 1  MULTIPOLYGON (((1745493 600...
#> 2  MULTIPOLYGON (((1803822 590...
#> 3  MULTIPOLYGON (((1860345 585...
#> 4  MULTIPOLYGON (((2049387 583...
#> 5  MULTIPOLYGON (((2024489 567...
#> 6  MULTIPOLYGON (((2024489 567...
#> 7  MULTIPOLYGON (((1740438 571...
#> 8  MULTIPOLYGON (((1866732 566...
#> 9  MULTIPOLYGON (((1881590 548...
#> 10 MULTIPOLYGON (((1557042 531...
nz_carto = cartogram_cont(nz, "Median_income", itermax = 5)
#> Mean size error for iteration 1: 2.55875465805575
#> Mean size error for iteration 2: 1.79272875527739
#> Mean size error for iteration 3: 1.43598715415039
#> Mean size error for iteration 4: 1.25491843756565
#> Mean size error for iteration 5: 1.15398221468619
tm_shape(nz_carto) + tm_polygons("Median_income")
#> Warning: The shape nz_carto is invalid. See sf::st_is_valid
```

![](https://i.imgur.com/LRS9nsG.png)

``` r

nz_poly = st_cast(nz, "POLYGON", do_split = FALSE)
#> Warning in st_cast.MULTIPOLYGON(X[[i]], ...): polygon from first part only
#> Warning in st_cast.MULTIPOLYGON(X[[i]], ...): polygon from first part only

#> Warning in st_cast.MULTIPOLYGON(X[[i]], ...): polygon from first part only
nz_carto_poly = cartogram_cont(nz_poly, "Median_income", itermax = 5)
#> Mean size error for iteration 1: 2.57220214146638
#> Mean size error for iteration 2: 1.80047638507022
#> Mean size error for iteration 3: 1.43788363281862
#> Mean size error for iteration 4: 1.25431793387714
#> Mean size error for iteration 5: 1.15282408713191
tm_shape(nz_carto_poly) + tm_polygons("Median_income")
```

![](https://i.imgur.com/QSW43Yt.png)

<sup>Created on 2019-11-02 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>