### PR TITLE
progress bar and parallel compute for cartogram_ncont

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ vignettes/*.pdf
 
 # pkgdown
 docs
+
+# private folder for draft test scripts
+private

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,8 +12,17 @@ Authors@R: c(
 Description: Construct continuous and non-contiguous area cartograms.
 URL: https://github.com/sjewo/cartogram, https://sjewo.github.io/cartogram/
 BugReports: https://github.com/sjewo/cartogram/issues
-Imports: methods, sf, packcircles
-Suggests: 
+Imports: 
+    methods,
+    sf,
+    packcircles,
+    progressr,
+    furrr,
+    parallelly,
+    future
 License: GPL-3
 Encoding: UTF-8
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
+Suggests: 
+    testthat (>= 3.0.0)
+Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,6 @@ Imports:
     methods,
     sf,
     packcircles,
-    progressr,
     furrr,
     parallelly,
     future

--- a/man/cartogram_ncont.Rd
+++ b/man/cartogram_ncont.Rd
@@ -6,11 +6,29 @@
 \alias{cartogram_ncont.sf}
 \title{Calculate Non-Contiguous Cartogram Boundaries}
 \usage{
-cartogram_ncont(x, weight, k = 1, inplace = TRUE)
+cartogram_ncont(
+  x,
+  weight,
+  k = 1,
+  inplace = TRUE,
+  n_cpu = parallelly::availableCores()
+)
 
-\method{cartogram_ncont}{SpatialPolygonsDataFrame}(x, weight, k = 1, inplace = TRUE)
+\method{cartogram_ncont}{SpatialPolygonsDataFrame}(
+  x,
+  weight,
+  k = 1,
+  inplace = TRUE,
+  n_cores = parallelly::availableCores()
+)
 
-\method{cartogram_ncont}{sf}(x, weight, k = 1, inplace = TRUE)
+\method{cartogram_ncont}{sf}(
+  x,
+  weight,
+  k = 1,
+  inplace = TRUE,
+  n_cores = parallelly::availableCores()
+)
 }
 \arguments{
 \item{x}{a polygon or multiplogyon sf object}
@@ -21,6 +39,8 @@ cartogram_ncont(x, weight, k = 1, inplace = TRUE)
 
 \item{inplace}{If TRUE, each polygon is modified in its original place, 
 if FALSE multi-polygons are centered on their initial centroid}
+
+\item{n_cpu}{Number of cores to use. Defaults to maximum available identified with \code{\link[parallelly]{availableCores}}.}
 }
 \value{
 An object of the same class as x with resized polygon boundaries

--- a/man/nc_cartogram.Rd
+++ b/man/nc_cartogram.Rd
@@ -16,6 +16,7 @@ nc_cartogram(shp, ...)
     \item{\code{k}}{Factor expansion for the unit with the greater value}
     \item{\code{inplace}}{If TRUE, each polygon is modified in its original place, 
 if FALSE multi-polygons are centered on their initial centroid}
+    \item{\code{n_cpu}}{Number of cores to use. Defaults to maximum available identified with \code{\link[parallelly]{availableCores}}.}
   }}
 }
 \description{

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,13 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
+
+library(testthat)
+library(cartogram)
+
+
+test_check("cartogram")

--- a/tests/testthat/test-cartogram_ncont.R
+++ b/tests/testthat/test-cartogram_ncont.R
@@ -1,0 +1,11 @@
+test_that("nc cartogram matches expected area", {
+  # Load North Carolina SIDS data
+  nc = sf::st_read(system.file("shape/nc.shp", package="sf"), quiet = TRUE)
+  # transform to NAD83 / UTM zone 16N
+  nc_utm <- sf::st_transform(nc, 26916)
+  
+  # Create cartogram
+  nc_utm_carto <- cartogram_ncont(nc_utm, weight = "BIR74")
+  cartogram_area <- as.integer((sum(nc_utm_carto |> st_area()))/1000)
+  expect_equal(cartogram_area, 22284872, tolerance = 0)
+})


### PR DESCRIPTION
Hi, trying to solve #35 myself I started with the simplest function `cartogram_ncont()`. I know there is an older pull request #28 , but this approach with just building on `furrr` and `future` seems simpler to me. Arguably it can be improved with better handling of the workers. E.g. instead of users specifying the `n_cores` in `cartogram_ncont()` they should be able to set the number of workers and type of parallel processing with `future` outside the function.

This PR results in `cartogram_ncont()` gaining both progress bar and parallel processing.

Before making changes to the code, I ran your default example from `cartogram_ncont()` function and obtained a control value of area of the resulting cartogram for `nc` from `sf` package. I wrote simple test for this area in the `tests` folder using `{testthat}`. The test passes with my updated code for `cartogram_ncont()`.